### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bindings/python/llbuild.py
+++ b/bindings/python/llbuild.py
@@ -223,8 +223,8 @@ class BuildEngine(_HandledObject):
         path = _Data(path)
         if not libllbuild.llb_buildengine_attach_db(
                 self._engine, path.key, schema_version, error):
-            raise IOError("unable to attach database; %r" % (
-                ffi.string(error),))
+            raise IOError("unable to attach database; {0!r}".format(
+                ffi.string(error)))
         
     def close(self):
         """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ source_suffix = '.rst'
 master_doc = 'contents'
 
 # General information about the project.
-copyright = u'%s, %s' % (datetime.datetime.now().year, project_author)
+copyright = u'{0!s}, {1!s}'.format(datetime.datetime.now().year, project_author)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -167,7 +167,7 @@ html_show_sourcelink = True
 #html_file_suffix = ''
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = '%sdoc' % project
+htmlhelp_basename = '{0!s}doc'.format(project)
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -181,7 +181,7 @@ htmlhelp_basename = '%sdoc' % project
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('contents', '%s.tex' % project, u'%s Documentation' % project,
+  ('contents', '{0!s}.tex'.format(project), u'{0!s} Documentation'.format(project),
    project_author, 'manual'),
 ]
 

--- a/examples/simple-make/simplebuild.py
+++ b/examples/simple-make/simplebuild.py
@@ -89,7 +89,7 @@ class DataDrivenEngine(llbuild.BuildEngine):
         rule_name = data["kind"] + "Rule"
         rule_class = self.namespace.get(rule_name)
         if rule_class is None:
-            raise RuntimeError("invalid rule: %r" % (data,))
+            raise RuntimeError("invalid rule: {0!r}".format(data))
         return rule_class(*data['args'])
 
     def task_is_complete(self, task, data, force_change=False):

--- a/examples/simple-make/util.py
+++ b/examples/simple-make/util.py
@@ -17,10 +17,10 @@ def message(msg):
         print >>sys.stdout, msg
 def note(msg):
     with _outputLock:
-        print >>sys.stderr, "note: %s" % msg
+        print >>sys.stderr, "note: {0!s}".format(msg)
 def error(msg):
     with _outputLock:
-        print >>sys.stderr, "error: %s" % msg
+        print >>sys.stderr, "error: {0!s}".format(msg)
 
 def get_stat_info(path):
     try:

--- a/utils/Xcode/LitXCTestAdaptor/LitTests.py
+++ b/utils/Xcode/LitXCTestAdaptor/LitTests.py
@@ -10,7 +10,7 @@ import lit.discovery
 # Ensure we have the appropriate environment variables
 built_products_dir = os.environ.get("BUILT_PRODUCTS_DIR")
 if not built_products_dir or not os.path.exists(built_products_dir):
-   raise RuntimeError("invalid BUILT_PRODUCTS_DIR: %r" % (built_products_dir,))
+   raise RuntimeError("invalid BUILT_PRODUCTS_DIR: {0!r}".format(built_products_dir))
 
 # Load the Lit test suite using the unittest style discovery.
 test_suite = lit.discovery.load_test_suite([os.path.join(built_products_dir,
@@ -25,7 +25,7 @@ def injectTestMethod(klass, test):
     
     # Inject the method.
     def runTest(obj):
-        print "Running Lit test: %s" % (test.id(),)
+        print "Running Lit test: {0!s}".format(test.id())
         result = test.defaultTestResult()
         test.run(result)
         

--- a/utils/create-dummy-ninja-from-DB.py
+++ b/utils/create-dummy-ninja-from-DB.py
@@ -29,7 +29,7 @@ class RuleResult(Base):
     dependencies = sqlalchemy.orm.relationship('RuleDependency')
 
     def __repr__(self):
-        return "%s%r" % (
+        return "{0!s}{1!r}".format(
             self.__class__.__name__, (self.id, self.key, self.value,
                                       self.built_at, self.computed_at))
 
@@ -42,7 +42,7 @@ class RuleDependency(Base):
     key = Column(String, nullable=False)
 
     def __repr__(self):
-        return "%s%r" % (
+        return "{0!s}{1!r}".format(
             self.__class__.__name__, (self.id, self.rule_id, self.key))
 
 def main():
@@ -69,8 +69,8 @@ def main():
     def get_key_name(key):
         name = node_names.get(key)
         if name is None:
-            node_names[key] = name = 'N%d' % (
-                len(node_names) - len(input_rules),)
+            node_names[key] = name = 'N{0:d}'.format(
+                len(node_names) - len(input_rules))
         return name
 
     # First, find all the "inputs" (leaf nodes).
@@ -79,7 +79,7 @@ def main():
                    if not rule.dependencies]
 
     # Assign all of the inputs special names.
-    node_names.update((rule.key, "I%d" % (i,))
+    node_names.update((rule.key, "I{0:d}".format(i))
                       for i,rule in enumerate(input_rules))
 
     seen_rules = set()
@@ -92,7 +92,7 @@ def main():
         if not dep_names:
             seen_inputs.add(name)
         else:
-            print "build %s: CAT %s" % (name, " ".join(dep_names))
+            print "build {0!s}: CAT {1!s}".format(name, " ".join(dep_names))
         seen_rules.add(name)
         seen_nodes.update(dep_names)
     print
@@ -100,19 +100,19 @@ def main():
     # Write a build statement to create all the inputs, so we can actually
     # execute the build.
     print "rule make-inputs"
-    print "  command = touch %s" % " ".join(sorted(seen_inputs))
+    print "  command = touch {0!s}".format(" ".join(sorted(seen_inputs)))
     print "build make-inputs: make-inputs"
     print
 
     # Write out a default target with the roots.
     roots = seen_rules - seen_nodes
-    print "default %s" % (" ".join(roots),)
+    print "default {0!s}".format(" ".join(roots))
 
     # Write the mappings, if requested.
     if args.show_mapping:
         print
         for key,name in sorted(node_names.items()):
-            print "# %s -> %s" % (key, name)
+            print "# {0!s} -> {1!s}".format(key, name)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:swift-llbuild?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:swift-llbuild?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
